### PR TITLE
update github actions to windows 2022

### DIFF
--- a/.github/workflows/pipeline_15.6.yaml
+++ b/.github/workflows/pipeline_15.6.yaml
@@ -6,18 +6,18 @@ on:
       dateInput:
         description: 'Expiration Date'
         required: true
-        default: '6/1/2025'
+        default: '12/31/2025'
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2022
     env:
       GITHUB_WORKSPACE_PACKAGES_PATH: ..\packages\ESAPI.15.6.0\lib\net45\
       SOLUTION_NAME: DoseRateEditor
       PROJECT_NAME_DOSERATEEDITOR: DoseRateEditor
       PROJECT_NAME_VIRTUALCONE: VirtualCones_MCB
       FOLDER_NAME_VIRTUALCONE: VirtualCones
-      CONFIGURATION: Debug
+      CONFIGURATION: Release
       MAJOR_VERSION: 1
       MINOR_VERSION: 0
       PATCH_VERSION: 0

--- a/.github/workflows/pipeline_16.1.yaml
+++ b/.github/workflows/pipeline_16.1.yaml
@@ -1,8 +1,3 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
 name: Build ESAPI Script - v16.1
 
 on:
@@ -11,19 +6,19 @@ on:
       dateInput:
         description: 'Expiration Date'
         required: true
-        default: '6/1/2025'
+        default: '12/31/2025'
 
 jobs:
   build:
     name: Build ESAPI Script - v16.1
-    runs-on: windows-2019
+    runs-on: windows-2022
     env:
       GITHUB_WORKSPACE_PACKAGES_PATH: ..\packages\ESAPI.16.1.0\lib\net461\
       SOLUTION_NAME: DoseRateEditor
       PROJECT_NAME_DOSERATEEDITOR: DoseRateEditor
       PROJECT_NAME_VIRTUALCONE: VirtualCones_MCB
       FOLDER_NAME_VIRTUALCONE: VirtualCones
-      CONFIGURATION: Debug
+      CONFIGURATION: Release
       MAJOR_VERSION: 1
       MINOR_VERSION: 0
       PATCH_VERSION: 0
@@ -67,6 +62,9 @@ jobs:
       uses: NuGet/setup-nuget@v1.0.6
       with:
         nuget-version: latest
+
+    - name: Download Microsoft NETFramework ReferenceAssemblies 4.6.1
+      run: nuget install Microsoft.NETFramework.ReferenceAssemblies.net461 -OutputDirectory .\packages
 
     - name: Download nuget packages for DoseRateEditor
       run: nuget install .\${{ env.PROJECT_NAME_DOSERATEEDITOR}}\packages.config -OutputDirectory .\packages

--- a/.github/workflows/pipeline_17.0.yaml
+++ b/.github/workflows/pipeline_17.0.yaml
@@ -6,18 +6,18 @@ on:
       dateInput:
         description: 'Expiration Date'
         required: true
-        default: '6/1/2025'
+        default: '12/31/2025'
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2022
     env:
       GITHUB_WORKSPACE_PACKAGES_PATH: ..\packages\ESAPI.17.0.0\lib\net48\
       SOLUTION_NAME: DoseRateEditor
       PROJECT_NAME_DOSERATEEDITOR: DoseRateEditor
       PROJECT_NAME_VIRTUALCONE: VirtualCones_MCB
       FOLDER_NAME_VIRTUALCONE: VirtualCones
-      CONFIGURATION: Debug
+      CONFIGURATION: Release
       MAJOR_VERSION: 1
       MINOR_VERSION: 0
       PATCH_VERSION: 0

--- a/.github/workflows/pipeline_18.0.yaml
+++ b/.github/workflows/pipeline_18.0.yaml
@@ -6,7 +6,7 @@ on:
       dateInput:
         description: 'Expiration Date'
         required: true
-        default: '6/1/2025'
+        default: '12/31/2025'
 
 jobs:
   build:
@@ -17,7 +17,7 @@ jobs:
       PROJECT_NAME_DOSERATEEDITOR: DoseRateEditor
       PROJECT_NAME_VIRTUALCONE: VirtualCones_MCB
       FOLDER_NAME_VIRTUALCONE: VirtualCones
-      CONFIGURATION: Debug
+      CONFIGURATION: Release
       MAJOR_VERSION: 1
       MINOR_VERSION: 0
       PATCH_VERSION: 0

--- a/DoseRateEditor/DoseRateEditor.csproj
+++ b/DoseRateEditor/DoseRateEditor.csproj
@@ -113,12 +113,12 @@
     </Reference>
     <Reference Include="VMS.TPS.Common.Model.API">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\Users\pszentiv\Downloads\ESAPI.16.1.5.49.nupkg\lib\net46\VMS.TPS.Common.Model.API.dll</HintPath>
+      <HintPath Condition="Exists('C:\Program Files (x86)\Varian\RTM\16.1\esapi\API')">C:\Program Files (x86)\Varian\RTM\16.1\esapi\API\VMS.TPS.Common.Model.API.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="VMS.TPS.Common.Model.Types">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\Users\pszentiv\Downloads\ESAPI.16.1.5.49.nupkg\lib\net46\VMS.TPS.Common.Model.Types.dll</HintPath>
+      <HintPath Condition="Exists('C:\Program Files (x86)\Varian\RTM\16.1\esapi\API')">C:\Program Files (x86)\Varian\RTM\16.1\esapi\API\VMS.TPS.Common.Model.Types.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="WindowsBase" />
@@ -222,4 +222,5 @@
     <EmbeddedResource Include="Resources\Frontal_crop.png" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\Microsoft.NETFramework.ReferenceAssemblies.net461.1.0.3\build\Microsoft.NETFramework.ReferenceAssemblies.net461.targets" Condition="'$(TargetFramework)' == 'net461' or Exists('..\packages\Microsoft.NETFramework.ReferenceAssemblies.net461.1.0.3\build\Microsoft.NETFramework.ReferenceAssemblies.net461.targets')" />
 </Project>


### PR DESCRIPTION
Update Github actions to use `windows-2022` and change build version from `Debug` to `Release`.